### PR TITLE
Update deps, convert into lib crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,6 @@ authors = ["aidatorajiro <kawarusosu@zoho.com>"]
 edition = "2018"
 
 [dependencies]
-nom = "5"
+nom = "6"
 byteorder = "1.3.2"
-num-bigint = "0.2.2"
+num-bigint = "0.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -342,18 +342,12 @@ pub fn flatten_keypointer(obj : Object, key_table : &mut Vec<Vec<u8>>) -> Object
   let kt = key_table;
 
   match obj {
-    Object::List(vo) => 
-    Object::List(single_map(vo, kt)),
-    Object::Hash(vt) => 
-    Object::Hash(pair_map(vt, kt)),
-    Object::StrI { content : vu, metadata : vt } => 
-    Object::StrI { content : vu, metadata : pair_map(vt, kt) },
-    Object::Instance { name : k, map : vt } => 
-    Object::Instance { name : k_proc(k, kt), map : pair_map(vt, kt) },
-    Object::InstanceFromString { name : k, data : vu } => 
-    Object::InstanceFromString { name : k_proc(k, kt), data : vu},
-    Object::InstanceFromArray { name : k, data : vo } => 
-    Object::InstanceFromArray { name : k_proc(k, kt), data : single_map(vo, kt) },
+    Object::List(vo) => Object::List(single_map(vo, kt)),
+    Object::Hash(vt) => Object::Hash(pair_map(vt, kt)),
+    Object::StrI { content : vu, metadata : vt } => Object::StrI { content : vu, metadata : pair_map(vt, kt) },
+    Object::Instance { name : k, map : vt } => Object::Instance { name : k_proc(k, kt), map : pair_map(vt, kt) },
+    Object::InstanceFromString { name : k, data : vu } => Object::InstanceFromString { name : k_proc(k, kt), data : vu},
+    Object::InstanceFromArray { name : k, data : vo } => Object::InstanceFromArray { name : k_proc(k, kt), data : single_map(vo, kt) },
     Object::Symbol(k) => Object::Symbol(k_proc(k, kt)),
     _  => obj
   }


### PR DESCRIPTION
Hello, I just found your crate and I found it really useful.
I just had to update a few deps and convert it into a lib crate to be able to use it.
I made few stylistic improvements, like tests module and remove extern crate (deprecated in 2018 edition)